### PR TITLE
Pluggable HTTP client

### DIFF
--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/MediaType.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/MediaType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms;
+
+public enum MediaType {
+
+    JSON("application/json"),
+    JSON_V1("application/vnd.doordeck.api-v1+json"),
+    JSON_V2("application/vnd.doordeck.api-v2+json"),
+    JWT("application/jwt");
+
+    private final String mimeType;
+
+    MediaType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/PluggableHttpClient.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/PluggableHttpClient.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface PluggableHttpClient {
+
+    ListenableFuture<ResponseDefinition> executeCall(RequestDefinition requestDefinition);
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/RequestDefinition.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/RequestDefinition.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms;
+
+import com.doordeck.sdk.core.util.ManifestUtils;
+import com.google.common.base.Optional;
+import com.google.common.collect.Multimap;
+import org.immutables.value.Value;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+@Value.Immutable
+public abstract class RequestDefinition {
+
+    private static final String DEFAULT_USER_AGENT = "Doordeck SDK - " + ManifestUtils.getManfiestVersion().or("Unknown");
+
+    public abstract URI baseUrl();
+    public abstract String path();
+    public abstract Multimap<String, Object> queryParameters();
+    public abstract RequestMethod method();
+    public abstract Optional<URI> origin();
+    public abstract Optional<String> request();
+    public abstract Optional<Class> responseType();
+    public abstract Optional<String> authToken();
+
+    @Value.Default
+    public String userAgent() {
+        return DEFAULT_USER_AGENT;
+    }
+
+    @Value.Default
+    public MediaType requestContentType() {
+        return MediaType.JSON;
+    }
+
+    @Value.Default
+    public MediaType responseContentType() {
+        return MediaType.JSON;
+    }
+
+    @Value.Derived
+    public URI endpoint() {
+        // Flatten query parameters into string
+        StringBuilder queryBuilder = new StringBuilder();
+        for (Map.Entry<String, Object> queryParam : queryParameters().entries()) {
+            queryBuilder.append(String.format("%s=%s", queryParam.getKey(), queryParam.getValue().toString()));
+            queryBuilder.append('&');
+        }
+        // Strip final delimiter
+        if (queryBuilder.length() > 0) {
+            queryBuilder.deleteCharAt(queryBuilder.length());
+        }
+
+        String query = queryBuilder.length() == 0 ? null : queryBuilder.toString();
+
+        try {
+            return new URI(baseUrl().getScheme(), baseUrl().getUserInfo(), baseUrl().getHost(), baseUrl().getPort(), path(), query, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/RequestMethod.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/RequestMethod.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms;
+
+public enum RequestMethod {
+
+    GET, DELETE, POST, PUT
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/ResponseDefinition.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/ResponseDefinition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms;
+
+import org.immutables.value.Value;
+
+import java.io.InputStream;
+
+@Value.Immutable
+public abstract class ResponseDefinition {
+
+    public abstract int statusCode();
+    public abstract InputStream entity();
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/http/client/BaseClient.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/http/client/BaseClient.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms.http.client;
+
+
+import com.doordeck.sdk.core.comms.ImmutableRequestDefinition;
+import com.doordeck.sdk.core.comms.PluggableHttpClient;
+import com.doordeck.sdk.core.comms.ResponseDefinition;
+import com.doordeck.sdk.core.util.ManifestUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.*;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+
+import static java.util.Objects.requireNonNull;
+
+public class BaseClient {
+
+    private static final URI DEFAULT_BASE_URL = URI.create("https://api.doordeck.com");
+
+    protected final PluggableHttpClient httpClient;
+    protected final ObjectMapper objectMapper;
+
+    private final Optional<URI> origin;
+    private final URI baseUrl;
+
+    public BaseClient(PluggableHttpClient httpClient, @Nullable URI baseUrl, @Nullable URI origin, ObjectMapper objectMapper) {
+        this.baseUrl = Optional.fromNullable(baseUrl).or(DEFAULT_BASE_URL);
+        this.origin = Optional.fromNullable(origin);
+        this.httpClient = requireNonNull(httpClient);
+        this.objectMapper = requireNonNull(objectMapper);
+    }
+
+    protected ImmutableRequestDefinition.Builder requestBuilder(String path) {
+        ImmutableRequestDefinition.Builder requestDefinition = ImmutableRequestDefinition.builder()
+                .baseUrl(baseUrl)
+                .origin(origin)
+                .path(path);
+
+        return requestDefinition;
+    }
+
+    protected <T> ListenableFuture<T> deserialize(final ListenableFuture<ResponseDefinition> response,
+                                                  final TypeReference<T> typeReference) {
+        AsyncFunction<ResponseDefinition, T> deserializer =
+                new AsyncFunction<ResponseDefinition, T>() {
+                    public ListenableFuture<T> apply(ResponseDefinition responseDefinition) {
+                        final SettableFuture<T> settableFuture = SettableFuture.create();
+                        try {
+                            settableFuture.set((T)objectMapper.readValue(responseDefinition.entity(), typeReference));
+                        } catch (IOException e) {
+                            settableFuture.setException(e);
+                        }
+                        return settableFuture;
+                    }
+                };
+        return Futures.transformAsync(response, deserializer, MoreExecutors.directExecutor());
+    }
+
+    protected <T> ListenableFuture<T> deserialize(final ListenableFuture<ResponseDefinition> response,
+                                                  final Class<T> type) {
+        AsyncFunction<ResponseDefinition, T> deserializer =
+                new AsyncFunction<ResponseDefinition, T>() {
+                    public ListenableFuture<T> apply(ResponseDefinition responseDefinition) {
+                        final SettableFuture<T> settableFuture = SettableFuture.create();
+                        try {
+                            settableFuture.set(objectMapper.readValue(responseDefinition.entity(), type));
+                        } catch (IOException e) {
+                            settableFuture.setException(e);
+                        }
+                        return settableFuture;
+                    }
+                };
+        return Futures.transformAsync(response, deserializer, MoreExecutors.directExecutor());
+    }
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/http/client/DeviceClient.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/http/client/DeviceClient.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.comms.http.client;
+
+import com.doordeck.sdk.core.comms.*;
+import com.doordeck.sdk.core.dto.device.Device;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+
+public class DeviceClient extends BaseClient {
+
+    private static final TypeReference<Set<Device>> DEVICE_SET_TYPE = new TypeReference<Set<Device>>() {};
+
+    public DeviceClient(PluggableHttpClient httpClient, @Nullable URI baseUrl,
+                        @Nullable URI origin, ObjectMapper objectMapper) {
+        super(httpClient, baseUrl, origin, objectMapper);
+    }
+
+    public void getDevices(String authToken, UUID siteId, FutureCallback<Set<Device>> callback) {
+        RequestDefinition requestDefinition = requestBuilder("/device/" + siteId.toString())
+                .authToken(authToken)
+                .responseContentType(MediaType.JSON)
+                .method(RequestMethod.GET)
+                .build();
+        ListenableFuture<ResponseDefinition> response = httpClient.executeCall(requestDefinition);
+        Futures.addCallback(deserialize(response, DEVICE_SET_TYPE), callback, MoreExecutors.directExecutor());
+    }
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/http/client/SiteClient.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/comms/http/client/SiteClient.java
@@ -1,0 +1,34 @@
+package com.doordeck.sdk.core.comms.http.client;
+
+import com.doordeck.sdk.core.comms.*;
+import com.doordeck.sdk.core.dto.site.Site;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.Set;
+
+public class SiteClient extends BaseClient {
+
+    private static final TypeReference<Set<Site>> SITE_SET_TYPE = new TypeReference<Set<Site>>() {};
+
+    public SiteClient(PluggableHttpClient httpClient, @Nullable URI baseUrl,
+                      @Nullable URI origin, ObjectMapper objectMapper) {
+        super(httpClient, baseUrl, origin, objectMapper);
+    }
+
+    public void getSites(String authToken, FutureCallback<Set<Site>> callback) {
+        RequestDefinition requestDefinition = requestBuilder("/site/")
+                .authToken(authToken)
+                .responseContentType(MediaType.JSON)
+                .method(RequestMethod.GET)
+                .build();
+        ListenableFuture<ResponseDefinition> response = httpClient.executeCall(requestDefinition);
+        Futures.addCallback(deserialize(response, SITE_SET_TYPE), callback, MoreExecutors.directExecutor());
+    }
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/dto/device/Device.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/dto/device/Device.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Doordeck Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.doordeck.sdk.core.dto.device;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import java.util.UUID;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableDevice.class)
+@JsonDeserialize(as = ImmutableDevice.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface Device {
+
+    @JsonProperty("id")
+    UUID deviceId();
+
+    String name();
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/dto/site/Site.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/dto/site/Site.java
@@ -1,0 +1,46 @@
+package com.doordeck.sdk.core.dto.site;
+
+import com.doordeck.sdk.core.jackson.deserializer.InstantSecondDeserializer;
+import com.doordeck.sdk.core.jackson.serializer.InstantSecondSerializer;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Optional;
+import org.immutables.value.Value;
+import org.joda.time.Instant;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSite.class)
+@JsonDeserialize(as = ImmutableSite.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface Site {
+
+    @JsonProperty("id")
+    UUID siteId();
+
+    String name();
+    String colour();
+    Optional<URI> logoUrl();
+
+    Optional<Double> longitude();
+    Optional<Double>  latitude();
+    Optional<Integer> radius();
+
+    Optional<UUID> createdBy();
+
+    @JsonProperty("created")
+    @JsonSerialize(using = InstantSecondSerializer.class)
+    @JsonDeserialize(using = InstantSecondDeserializer.class)
+    Instant createdAt();
+
+    @JsonProperty("updated")
+    @JsonSerialize(using = InstantSecondSerializer.class)
+    @JsonDeserialize(using = InstantSecondDeserializer.class)
+    Instant updatedAt();
+
+
+}

--- a/doordeck-core/src/main/java/com/doordeck/sdk/core/util/ManifestUtils.java
+++ b/doordeck-core/src/main/java/com/doordeck/sdk/core/util/ManifestUtils.java
@@ -1,0 +1,31 @@
+package com.doordeck.sdk.core.util;
+
+import com.google.common.base.Optional;
+
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+public class ManifestUtils {
+
+    private ManifestUtils() { /* static class */ }
+
+    public static Optional<String> getManfiestVersion() {
+        try {
+            Class clazz = ManifestUtils.class;
+            String className = clazz.getSimpleName() + ".class";
+            String classPath = clazz.getResource(className).toString();
+            if (!classPath.startsWith("jar")) {
+                // Class not from JAR
+                return Optional.absent();
+            }
+
+            String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
+            Manifest manifest = new Manifest(new URL(manifestPath).openStream());
+            Attributes attr = manifest.getMainAttributes();
+            return Optional.fromNullable(attr.getValue("Manifest-Version"));
+        } catch (Exception e) {
+            return Optional.absent();
+        }
+    }
+}

--- a/doordeck-http-jersey/pom.xml
+++ b/doordeck-http-jersey/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>doordeck-java-sdk-pom</artifactId>
+        <groupId>com.doordeck.sdk</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>doordeck-http-jersey</artifactId>
+
+    <properties>
+        <jersey.version>2.28</jersey.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.doordeck.sdk</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Jersey Client -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/doordeck-http-jersey/src/main/java/com/doordeck/sdk/http/client/JerseyClientAdapter.java
+++ b/doordeck-http-jersey/src/main/java/com/doordeck/sdk/http/client/JerseyClientAdapter.java
@@ -1,0 +1,74 @@
+package com.doordeck.sdk.http.client;
+
+import com.doordeck.sdk.core.comms.ImmutableResponseDefinition;
+import com.doordeck.sdk.core.comms.PluggableHttpClient;
+import com.doordeck.sdk.core.comms.RequestDefinition;
+import com.doordeck.sdk.core.comms.ResponseDefinition;
+import com.google.common.net.HttpHeaders;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+
+import javax.ws.rs.client.*;
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+
+public class JerseyClientAdapter implements PluggableHttpClient {
+
+    private final Client client;
+
+    public JerseyClientAdapter() {
+        this.client = JerseyClientBuilder.createClient();
+    }
+
+    @Override
+    public ListenableFuture<ResponseDefinition> executeCall(RequestDefinition requestDefinition) {
+
+        Invocation.Builder builder = client.target(requestDefinition.endpoint())
+                .request()
+                .header(HttpHeaders.USER_AGENT, requestDefinition.userAgent())
+                .accept(requestDefinition.responseContentType().getMimeType());
+
+        // Add origin
+        if (requestDefinition.origin().isPresent()) {
+            builder.header(HttpHeaders.ORIGIN, requestDefinition.origin().get());
+        }
+
+        // Add authentication
+        if (requestDefinition.authToken().isPresent()) {
+            builder.header(HttpHeaders.AUTHORIZATION, "Bearer " + requestDefinition.authToken().get());
+        }
+
+        // Setup future callback
+        final SettableFuture<ResponseDefinition> responseFuture = SettableFuture.create();
+        InvocationCallback<Response> invocationCallback = new InvocationCallback<Response>() {
+            @Override
+            public void completed(Response response) {
+                if (response.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL)) {
+                    responseFuture.set(ImmutableResponseDefinition.builder()
+                            .statusCode(response.getStatus())
+                            .entity(response.readEntity(InputStream.class))
+                            .build());
+                } else {
+                    responseFuture.setException(new IllegalStateException(response.getStatusInfo().toString()));
+                }
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                responseFuture.setException(throwable);
+            }
+        };
+
+        // Send the request
+        if (requestDefinition.request().isPresent()) {
+            Entity entity = Entity.entity(requestDefinition.request().orNull(), requestDefinition.requestContentType().getMimeType());
+            builder.async().method(requestDefinition.method().name(), entity, invocationCallback);
+        } else {
+            builder.async().method(requestDefinition.method().name(), invocationCallback);
+        }
+
+        return responseFuture;
+    }
+
+}

--- a/doordeck-http-jersey/src/test/java/com/doordeck/sdk/http/client/JerseyClientAdapterTest.java
+++ b/doordeck-http-jersey/src/test/java/com/doordeck/sdk/http/client/JerseyClientAdapterTest.java
@@ -1,0 +1,46 @@
+package com.doordeck.sdk.http.client;
+
+import com.doordeck.sdk.core.comms.PluggableHttpClient;
+import com.doordeck.sdk.core.comms.http.client.DeviceClient;
+import com.doordeck.sdk.core.dto.device.Device;
+import com.doordeck.sdk.core.jackson.Jackson;
+import com.google.common.util.concurrent.FutureCallback;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class JerseyClientAdapterTest {
+
+    String authToken = System.getenv("DOORDECK_AUTH_TOKEN");
+
+    @Test
+    public void testGetDevices() throws Exception {
+        PluggableHttpClient httpClient = new JerseyClientAdapter();
+        DeviceClient deviceClient = new DeviceClient(httpClient, null, null, Jackson.sharedObjectMapper());
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        FutureCallback<Set<Device>> deviceCallback = new FutureCallback<Set<Device>>() {
+            @Override
+            public void onSuccess(@NullableDecl Set<Device> devices) {
+                System.out.println(devices);
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                System.err.println(t.getMessage());
+                countDownLatch.countDown();
+            }
+        };
+
+        deviceClient.getDevices(authToken, UUID.fromString("7659e430-4a28-11e8-bf0b-bffab372a82e"), deviceCallback);
+
+        // Prevent test from exiting until threads done
+        countDownLatch.await(30, TimeUnit.SECONDS);
+    }
+
+}

--- a/doordeck-http-okhttp/pom.xml
+++ b/doordeck-http-okhttp/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>doordeck-java-sdk-pom</artifactId>
+        <groupId>com.doordeck.sdk</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>doordeck-http-okhttp</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.doordeck.sdk</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.13.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/doordeck-http-okhttp/src/main/java/com/doordeck/sdk/http/client/OkHttpClientAdapter.java
+++ b/doordeck-http-okhttp/src/main/java/com/doordeck/sdk/http/client/OkHttpClientAdapter.java
@@ -1,0 +1,110 @@
+package com.doordeck.sdk.http.client;
+
+import com.doordeck.sdk.core.comms.ImmutableResponseDefinition;
+import com.doordeck.sdk.core.comms.PluggableHttpClient;
+import com.doordeck.sdk.core.comms.RequestDefinition;
+import com.doordeck.sdk.core.comms.ResponseDefinition;
+import com.google.common.net.HttpHeaders;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import okhttp3.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+public class OkHttpClientAdapter implements PluggableHttpClient {
+
+    private static final String[] TRUSTED_CERTIFICATES = {
+            "sha256/++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=",
+            "sha256/f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=",
+            "sha256/NqvDJlas/GRcYbcWE8S/IceH9cq77kg0jVhZeAPXq8k=",
+            "sha256/9+ze1cZgR9KO1kZrVDxA4HQ6voHRCSVNz4RdTCx4U8U=",
+            "sha256/KwccWaCgrnaw6tsrrSO61FgLacNgG2MMLq8GE6+oP5I=",
+            "sha256/tYU57KoTkhzNuA0400h1/eZHHFoVnZvu8vpvmZg71hE=",
+            "sha256/ZLtb2AMR+j9TvZlATKuHYq1uBIRH0Kl/IZ/OyhZh83w=",
+            "sha256/G9pa//g3gTgL9wgZj599LbHgZ/FLuep7rnCqwLAwXns=",
+            "sha256/fFO133kTXZr2GV72u3OrmMLImVC4krGS3/14TbklpBw=",
+            "sha256/F3CN/yt/rsnLG1IV67JCHZewVDyTb6ydbgK5LyDlxwc="
+    };
+
+    private final OkHttpClient client;
+
+    /**
+     * Create an OkHttp client adapter with sensible defaults
+     */
+    public OkHttpClientAdapter() {
+        this.client = new OkHttpClient.Builder()
+                .connectionSpecs(Collections.singletonList(ConnectionSpec.RESTRICTED_TLS))
+                .protocols(Arrays.asList(Protocol.HTTP_2, Protocol.HTTP_1_1))
+                .retryOnConnectionFailure(true)
+                .cookieJar(CookieJar.NO_COOKIES) // Disable cookies
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .certificatePinner(new CertificatePinner.Builder()
+                        .add("*", TRUSTED_CERTIFICATES)
+                        .build())
+                .build();
+    }
+
+    public OkHttpClientAdapter(OkHttpClient client) {
+        this.client = requireNonNull(client);
+    }
+
+    @Override
+    public ListenableFuture<ResponseDefinition> executeCall(RequestDefinition requestDefinition) {
+
+        Request.Builder request = new Request.Builder().url(requestDefinition.endpoint().toString())
+                .header(HttpHeaders.USER_AGENT, requestDefinition.userAgent());
+
+        // Process body
+        if (requestDefinition.request().isPresent()) {
+            MediaType mediaType = MediaType.get(requestDefinition.requestContentType().getMimeType());
+            RequestBody requestBody = RequestBody.create(mediaType, requestDefinition.request().get());
+            request.method(requestDefinition.method().name(), requestBody);
+        } else {
+            request.method(requestDefinition.method().name(), null);
+        }
+
+        // Add authentication
+        if (requestDefinition.authToken().isPresent()) {
+            request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + requestDefinition.authToken().get());
+        }
+
+        // Add origin
+        if (requestDefinition.origin().isPresent()) {
+            request.addHeader(HttpHeaders.ORIGIN, requestDefinition.origin().get().toString());
+        }
+
+        // Handle response
+        final SettableFuture<ResponseDefinition> responseFuture = SettableFuture.create();
+        Callback responseCallback = new Callback() {
+
+            @Override
+            public void onFailure(Call call, IOException e) {
+                responseFuture.setException(e);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) {
+                if (response.isSuccessful()) {
+                    responseFuture.set(ImmutableResponseDefinition.builder()
+                            .statusCode(response.code())
+                            .entity(response.body().byteStream())
+                            .build());
+                } else {
+                    responseFuture.setException(new IOException(response.message()));
+                }
+            }
+
+        };
+
+        client.newCall(request.build()).enqueue(responseCallback);
+
+        return responseFuture;
+    }
+}

--- a/doordeck-http-okhttp/src/test/java/com/doordeck/sdk/http/client/OkHttpClientAdapterTest.java
+++ b/doordeck-http-okhttp/src/test/java/com/doordeck/sdk/http/client/OkHttpClientAdapterTest.java
@@ -1,0 +1,77 @@
+package com.doordeck.sdk.http.client;
+
+import com.doordeck.sdk.core.comms.PluggableHttpClient;
+import com.doordeck.sdk.core.comms.http.client.DeviceClient;
+import com.doordeck.sdk.core.comms.http.client.SiteClient;
+import com.doordeck.sdk.core.dto.device.Device;
+import com.doordeck.sdk.core.dto.site.Site;
+import com.doordeck.sdk.core.jackson.Jackson;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class OkHttpClientAdapterTest {
+
+    String authToken = System.getenv("DOORDECK_AUTH_TOKEN");
+
+    @Test
+    public void getDevicesTest() throws Exception {
+        PluggableHttpClient httpClient = new OkHttpClientAdapter();
+        DeviceClient deviceClient = new DeviceClient(httpClient, null, null, Jackson.sharedObjectMapper());
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        FutureCallback<Set<Device>> deviceCallback = new FutureCallback<Set<Device>>() {
+            @Override
+            public void onSuccess(@NullableDecl Set<Device> devices) {
+                System.out.println(devices);
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                System.err.println(t.getMessage());
+                countDownLatch.countDown();
+            }
+        };
+
+        deviceClient.getDevices(authToken, UUID.fromString("7659e430-4a28-11e8-bf0b-bffab372a82e"), deviceCallback);
+
+        // Prevent test from exiting until threads done
+        countDownLatch.await(30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void getSiteTest() throws Exception {
+        PluggableHttpClient httpClient = new OkHttpClientAdapter();
+        SiteClient siteClient = new SiteClient(httpClient, null, null, Jackson.sharedObjectMapper());
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        FutureCallback<Set<Site>> siteCallback = new FutureCallback<Set<Site>>() {
+            @Override
+            public void onSuccess(@NullableDecl Set<Site> sites) {
+                System.out.println(sites);
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                System.err.println(t.getMessage());
+                countDownLatch.countDown();
+            }
+        };
+
+        siteClient.getSites(authToken, siteCallback);
+
+        // Prevent test from exiting until threads done
+        countDownLatch.await(30, TimeUnit.SECONDS);
+    }
+
+}

--- a/doordeck-signer/src/main/java/com/doordeck/sdk/jwt/signer/BaseSigner.java
+++ b/doordeck-signer/src/main/java/com/doordeck/sdk/jwt/signer/BaseSigner.java
@@ -20,7 +20,6 @@ import com.doordeck.sdk.core.jackson.Jackson;
 import com.doordeck.sdk.jwt.Claims;
 import com.doordeck.sdk.jwt.Header;
 import com.doordeck.sdk.jwt.JOSEException;
-import com.doordeck.sdk.jwt.Claims;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <module>doordeck-core</module>
         <module>doordeck-signer</module>
         <module>doordeck-android</module>
+        <module>doordeck-http-jersey</module>
+        <module>doordeck-http-okhttp</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
To better support third-party app developers in both Android and on the server, I'm proposing a HTTP client with support for Jersey and okhttp to cover common use cases. This PR is incomplete, it only contains a couple of tests calls to evaluation the approach taken. 

Currently missing:
- Exception mapping
- All of the sensible HTTP calls