### PR TITLE
2fa fix - sdkMode

### DIFF
--- a/sampleApp/src/main/java/com/doordeck/doordecksdk/MainActivity.kt
+++ b/sampleApp/src/main/java/com/doordeck/doordecksdk/MainActivity.kt
@@ -56,6 +56,10 @@ class MainActivity : AppCompatActivity() {
             override fun unlockFailed() {
                 Toast.makeText(applicationContext, "Unlock Failed", LENGTH_SHORT).show()
             }
+
+            override fun verificationNeeded() {
+                Toast.makeText(applicationContext, "2fa needed", LENGTH_SHORT).show()
+            }
         })
     }
 

--- a/ui/src/main/java/com/doordeck/sdk/common/events/UnlockCallback.kt
+++ b/ui/src/main/java/com/doordeck/sdk/common/events/UnlockCallback.kt
@@ -8,6 +8,7 @@ interface UnlockCallback
     fun unlockSuccess()
     fun unlockFailed()
     fun invalidAuthToken()
+    fun verificationNeeded()
     fun notAuthenticated()
 }
 

--- a/ui/src/main/java/com/doordeck/sdk/common/manager/CertificateManager.kt
+++ b/ui/src/main/java/com/doordeck/sdk/common/manager/CertificateManager.kt
@@ -1,9 +1,8 @@
 package com.doordeck.sdk.common.manager
 
-import android.content.Context
+import com.doordeck.sdk.common.events.UnlockCallback
 import com.doordeck.sdk.dto.certificate.CertificateChain
 import com.doordeck.sdk.dto.certificate.ImmutableRegisterEphemeralKey
-import com.doordeck.sdk.ui.verify.VerifyDeviceActivity
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -21,7 +20,7 @@ object CertificateManager {
      * If the server responds with a 423, the user needs to verify its device with a 2 FA
      * @param publicKey public key of the user
      */
-    fun getCertificatesAsync(publicKey: PublicKey, ctx: Context) {
+    fun getCertificatesAsync(publicKey: PublicKey, callback: UnlockCallback? = null) {
         val ephKey = ImmutableRegisterEphemeralKey.builder().ephemeralKey(publicKey).build()
         val request = Doordeck.client!!.certificateService().registerEphemeralKey(ephKey)
         request.enqueue(object : Callback<CertificateChain> {
@@ -30,7 +29,7 @@ object CertificateManager {
                 if (response.body() != null) Doordeck.storeCertificates(Doordeck.certificateChain!!)
                 if (response.code() == 423) {
                     Doordeck.status = AuthStatus.TWO_FACTOR_AUTH_NEEDED
-                    VerifyDeviceActivity.start(ctx)
+                    callback?.verificationNeeded()
                 } else {
                     Doordeck.status = AuthStatus.AUTHORIZED
                     Doordeck.storeLaststatus(Doordeck.status)

--- a/ui/src/main/java/com/doordeck/sdk/common/manager/Doordeck.kt
+++ b/ui/src/main/java/com/doordeck/sdk/common/manager/Doordeck.kt
@@ -94,7 +94,7 @@ object Doordeck {
      * @param darkmode (Optional) set dark or light theme of the sdk.
      * @return Doordeck the current instance of the SDK
      */
-    fun initialize(ctx: Context, authToken: String? = null, darkMode: Boolean = false, callback: UnlockCallback? = null): Doordeck {
+    fun initialize(ctx: Context, authToken: String? = null, darkMode: Boolean = false): Doordeck {
         Preconditions.checkNotNull(ctx!!, "Context can't be null")
         if (authToken != null) {
             if (this.apiKey == null) {

--- a/ui/src/main/java/com/doordeck/sdk/common/manager/Doordeck.kt
+++ b/ui/src/main/java/com/doordeck/sdk/common/manager/Doordeck.kt
@@ -94,7 +94,7 @@ object Doordeck {
      * @param darkmode (Optional) set dark or light theme of the sdk.
      * @return Doordeck the current instance of the SDK
      */
-    fun initialize(ctx: Context, authToken: String? = null, darkMode: Boolean = false): Doordeck {
+    fun initialize(ctx: Context, authToken: String? = null, darkMode: Boolean = false, callback: UnlockCallback? = null): Doordeck {
         Preconditions.checkNotNull(ctx!!, "Context can't be null")
         if (authToken != null) {
             if (this.apiKey == null) {
@@ -110,12 +110,12 @@ object Doordeck {
                 this.storeTheme(darkMode)
                 if (getStoredAuthToken() != authToken) {
                     storeToken(authToken)
-                    keys?.public?.let { CertificateManager.getCertificatesAsync(it, ctx) }
+                    keys?.public?.let { CertificateManager.getCertificatesAsync(it) }
                 } else {
                     if (certificateChain == null) {
                         certificateChain = getStoredCertificateChain()
                         if (certificateChain == null) {
-                            keys?.public?.let { CertificateManager.getCertificatesAsync(it, ctx) }
+                            keys?.public?.let { CertificateManager.getCertificatesAsync(it) }
                             var lastStatus = getLastStatus()
                             if (lastStatus != null) Doordeck.status = lastStatus
                         } else {
@@ -123,7 +123,7 @@ object Doordeck {
                                 status = AuthStatus.AUTHORIZED
                                 certificateLoaded = true
                             } else {
-                                keys?.public?.let { CertificateManager.getCertificatesAsync(it, ctx) }
+                                keys?.public?.let { CertificateManager.getCertificatesAsync(it) }
                             }
                         }
                     } else {
@@ -131,7 +131,7 @@ object Doordeck {
                             status = AuthStatus.AUTHORIZED
                             certificateLoaded = true
                         } else {
-                            keys?.public?.let { CertificateManager.getCertificatesAsync(it, ctx) }
+                            keys?.public?.let { CertificateManager.getCertificatesAsync(it) }
                         }
                     }
                 }
@@ -167,7 +167,7 @@ object Doordeck {
         storeToken(authToken)
         storeTheme(darkMode)
         createHttpClient()
-        keys?.public?.let { CertificateManager.getCertificatesAsync(it, ctx) }
+        keys?.public?.let { CertificateManager.getCertificatesAsync(it) }
     }
 
     /**
@@ -222,6 +222,12 @@ object Doordeck {
             callback?.notAuthenticated()
             return
         }
+
+        if (status == AuthStatus.TWO_FACTOR_AUTH_NEEDED) {
+            callback?.verificationNeeded()
+            return
+        }
+
         jwtToken?.let { header ->
             if (isValidityApiKey(header) && apiKey != null) {
 

--- a/ui/src/main/java/com/doordeck/sdk/common/manager/Doordeck.kt
+++ b/ui/src/main/java/com/doordeck/sdk/common/manager/Doordeck.kt
@@ -13,7 +13,6 @@ import com.doordeck.sdk.common.models.EventAction
 import com.doordeck.sdk.common.models.JWTHeader
 import com.doordeck.sdk.common.utils.JWTContentUtils
 import com.doordeck.sdk.common.utils.LOG
-import com.doordeck.sdk.dto.Role
 import com.doordeck.sdk.dto.certificate.CertificateChain
 import com.doordeck.sdk.dto.device.Device
 import com.doordeck.sdk.dto.operation.Operation
@@ -28,8 +27,6 @@ import io.reactivex.Observable
 import java.net.URI
 import java.security.GeneralSecurityException
 import java.security.KeyPair
-import java.security.PublicKey
-import java.time.Instant
 import java.util.*
 import kotlin.properties.Delegates.observable
 
@@ -78,6 +75,9 @@ object Doordeck {
     }
     // Check if certificates are loaded
     var onCertLoaded : ((Boolean, Boolean) -> Unit)? = null
+
+    // Sdk Mode
+    private var sdkMode: Boolean = false
 
 
 
@@ -230,11 +230,12 @@ object Doordeck {
 
         jwtToken?.let { header ->
             if (isValidityApiKey(header) && apiKey != null) {
-
-                when (type) {
-                    ScanType.QR -> QRcodeActivity.start(context)
-                    ScanType.NFC -> NFCActivity.start(context)
-                    ScanType.UNLOCK -> UnlockActivity.start(context, deviceToUnlock!!)
+                if (!sdkMode) {
+                    when (type) {
+                        ScanType.QR -> QRcodeActivity.start(context)
+                        ScanType.NFC -> NFCActivity.start(context)
+                        ScanType.UNLOCK -> UnlockActivity.start(context, deviceToUnlock!!)
+                    }
                 }
                 this.unlockCallback = callback
             } else


### PR DESCRIPTION
**2FA FIX**
This issue was showing the `VerifyActivity` every time the SDK initializes (and receives a 423). This would have to show when we try to unlock the door.
So my fix is not starting an Activity but calling a callback. That callback is in many of the functions, but just in case `showUnlock`, it will open the Verification Screen.

**`sdkMode`**
Introduced `sdkMode` that prevents of opening any screen when `showUnlock` is called