### PR TITLE
Enable transition for only doordeck URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The 2nd param is optional, and correspond to the theme to use. Light or Dark. By
 ``` 
 
 #### Tweak the NFC Uri settings
-Default values for a NFC Uri link would be `https://doordeck.link/uuid/${uuid}`.
+Default values for a NFC Uri link would be `https://doordeck.link/${uuid}`.
 If you want to customise this values, go to your main project's `build.gradle`, inside `buildscript { }` define:
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ If you want to customise this values, go to your main project's `build.gradle`, 
 ext.nfcUri = [
     "scheme": "https", // Replace with the scheme you want or leave it empty
     "host": "doordeck.link", // Replace with the host you want or leave it empty
-    "pathPrefix": "/uuid", // Replace with the pathPrefix you want or leave it empty
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,20 @@ The 2nd param is optional, and correspond to the theme to use. Light or Dark. By
      * @return Doordeck the current instance of the SDK
      */
     fun initialize(apiKey: String, darkMode: Boolean = true): Doordeck
+``` 
+
+#### Tweak the NFC Uri settings
+Default values for a NFC Uri link would be `https://doordeck.link/uuid/${uuid}`.
+If you want to customise this values, go to your main project's `build.gradle`, inside `buildscript { }` define:
+
 ```
-    
+ext.nfcUri = [
+    "scheme": "https", // Replace with the scheme you want or leave it empty
+    "host": "doordeck.link", // Replace with the host you want or leave it empty
+    "pathPrefix": "/uuid", // Replace with the pathPrefix you want or leave it empty
+]
+```
+
 #### Proguard
 
 When enabling `minifyEnabled`, proguard and or R8 tools, you need to include these rules to the proguard-rules.pro:

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,12 @@ buildscript {
             'okhttp': "com.squareup.okhttp3:okhttp:${versions.okhttp}",
     ]
 
+    ext.nfcUri = [
+        "scheme": "https",
+        "host": "doordeck.link",
+        "pathPrefix": "/uuid",
+    ]
+
     dependencies {
         classpath 'com.android.tools:r8:8.1.56'
         classpath 'com.android.tools.build:gradle:8.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
     ext.nfcUri = [
         "scheme": "https",
         "host": "doordeck.link",
-        "pathPrefix": "/uuid",
     ]
 
     dependencies {

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -30,11 +30,9 @@ android {
         // Fallback values for tiles
         def fallbackNfcUriHost = "doordeck.link"
         def fallbackNfcUriScheme = "https"
-        def fallBackUriPathPrefix = "/uuid"
 
         type.manifestPlaceholders['nfc_uri_host'] = project.properties.get("nfcUri").getOrDefault("host", fallbackNfcUriHost)
         type.manifestPlaceholders['nfc_uri_scheme'] = project.properties.get("nfcUri").getOrDefault("scheme", fallbackNfcUriScheme)
-        type.manifestPlaceholders['nfc_uri_path_prefix'] = project.properties.get("nfcUri").getOrDefault("pathPrefix", fallBackUriPathPrefix)
 
     }
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: "maven-publish"
 
-group='com.github.doordeck'
+group = 'com.github.doordeck'
 
 android {
 
@@ -26,6 +26,17 @@ android {
         exclude 'META-INF/atomicfu.kotlin_module'
     }
 
+    buildTypes.each { type ->
+        // Fallback values for tiles
+        def fallbackNfcUriHost = "doordeck.link"
+        def fallbackNfcUriScheme = "https"
+        def fallBackUriPathPrefix = "/uuid"
+
+        type.manifestPlaceholders['nfc_uri_host'] = project.properties.get("nfcUri").getOrDefault("host", fallbackNfcUriHost)
+        type.manifestPlaceholders['nfc_uri_scheme'] = project.properties.get("nfcUri").getOrDefault("scheme", fallbackNfcUriScheme)
+        type.manifestPlaceholders['nfc_uri_path_prefix'] = project.properties.get("nfcUri").getOrDefault("pathPrefix", fallBackUriPathPrefix)
+
+    }
 
     buildTypes {
         debug {
@@ -72,7 +83,7 @@ buildscript {
 
 dependencies {
     api(project(":api"))
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     implementation 'com.github.adorsys:secure-storage-android:0.0.2'
     implementation "org.immutables:value-annotations:2.7.5" // or implementation, or compileOnly

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-feature android:name="android.hardware.camera.autofocus" />
 
     <uses-sdk tools:overrideLibrary="com.google.zxing.client.android" />
-    
+
     <application>
         <activity
             android:name="com.doordeck.sdk.ui.unlock.UnlockActivity"
@@ -35,10 +35,22 @@
             android:screenOrientation="portrait"
             android:exported="true"
             android:excludeFromRecents="true">
+
+            <!-- Old mimetype to keep backwards compatibility -->
             <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
+
+            <!-- New mimetype to migrate soon -->
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:host="${nfc_uri_host}"
+                    android:pathPrefix="${nfc_uri_path_prefix}"
+                    android:scheme="${nfc_uri_scheme}" />
             </intent-filter>
         </activity>
         <activity android:name="com.doordeck.sdk.ui.verify.VerifyDeviceActivity"

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -49,7 +49,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data
                     android:host="${nfc_uri_host}"
-                    android:pathPrefix="${nfc_uri_path_prefix}"
                     android:scheme="${nfc_uri_scheme}" />
             </intent-filter>
         </activity>

--- a/ui/src/main/java/com/doordeck/sdk/ui/nfc/NFCActivity.kt
+++ b/ui/src/main/java/com/doordeck/sdk/ui/nfc/NFCActivity.kt
@@ -3,6 +3,7 @@ package com.doordeck.sdk.ui.nfc
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.nfc.NfcAdapter
 import android.nfc.NfcManager
 import android.os.Bundle
@@ -87,8 +88,10 @@ internal class NFCActivity : BaseActivity(), NFCView {
 
 
     override fun unlockFromTileId(tileId: String) {
+        val uuid = Uri.parse(tileId).lastPathSegment ?: ""
+
         intent.action = ""
-        UnlockActivity.start(this, tileId, comingFrom = COMING_FROM_NFC)
+        UnlockActivity.start(this, uuid, comingFrom = COMING_FROM_NFC)
         finish()
     }
 

--- a/ui/src/main/java/com/doordeck/sdk/ui/nfc/NFCManager.java
+++ b/ui/src/main/java/com/doordeck/sdk/ui/nfc/NFCManager.java
@@ -25,13 +25,8 @@ public class NFCManager {
         String action = intent.getAction();
 
         if (NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action)) {
-            String type = intent.getType();
-            if (MIME_TEXT_PLAIN.equals(type)) {
-                Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
-                verifyContentTag(tag, callback);
-            } else {
-                Log.d(TAG, "Wrong mime type: " + type);
-            }
+            Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
+            verifyContentTag(tag, callback);
         } else if (NfcAdapter.ACTION_TECH_DISCOVERED.equals(action)) {
             // In case we would still use the Tech Discovered Intent
             Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
@@ -57,7 +52,7 @@ public class NFCManager {
 
         NdefRecord[] records = ndefMessage.getRecords();
         for (NdefRecord ndefRecord : records) {
-            if (ndefRecord.getTnf() == NdefRecord.TNF_WELL_KNOWN && Arrays.equals(ndefRecord.getType(), NdefRecord.RTD_TEXT)) {
+            if (ndefRecord.getTnf() == NdefRecord.TNF_WELL_KNOWN && Arrays.equals(ndefRecord.getType(), NdefRecord.RTD_URI)) {
                 try {
                     callback.onReadSuccess(readText(ndefRecord));
                 } catch (UnsupportedEncodingException e) {

--- a/ui/src/main/java/com/doordeck/sdk/ui/qrcode/QRcodeView.kt
+++ b/ui/src/main/java/com/doordeck/sdk/ui/qrcode/QRcodeView.kt
@@ -61,10 +61,10 @@ internal class QRcodeView : CompoundBarcodeView {
             override fun barcodeResult(result: BarcodeResult) {
                 val scan = result.toString()
                 LOG.d(TAG, "scanned data : $result")
-                val id = scan.substring(scan.lastIndexOf("/") + 1)
-                if (isUUID(id)) {
+                val uuid = scan.substring(scan.lastIndexOf("/") + 1)
+                if (isUUID(uuid)) {
                     pause()
-                    (context as? Activity)?.let { activity -> UnlockActivity.start(activity, id, comingFrom = COMING_FROM_QR_SCAN) }
+                    (context as? Activity)?.let { activity -> UnlockActivity.start(activity, uuid, comingFrom = COMING_FROM_QR_SCAN) }
                 } else {
                     // show error
                     LOG.d(TAG, "not a uuid")


### PR DESCRIPTION
- Add compatibility for tags that only contain an URI such as `https://doordeck.link/${uuid}`
- Fix how the `UUID` is extracted
- The current NFC writer writes two records where the first is `text/plain` and the second is a correct `URI`, so even if we detect a `text/plain`, we will care about the URI which in the old configuration it was placed in the second position.
- Add compatibility to change and customise the `scheme`, `host` and `pathPrefix` when reading NFC URIs.