### PR TITLE
[Legacy update] Accept at least API 35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
             'okhttp': '4.12.0',
             'bouncycastle': '1.78.1',
             'findbugs': '3.0.2',
-            'jackson': '2.17.2',
+            'jackson': '2.19.2',
             'retrofit': '2.6.2'
     ]
 
@@ -30,9 +30,9 @@ buildscript {
     ]
 
     dependencies {
-        classpath 'com.android.tools:r8:8.3.37'
-        classpath "com.android.tools.build:gradle:8.5.0"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        classpath 'com.android.tools:r8:8.11.18'
+        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Tue Jul 09 14:07:11 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sampleApp/build.gradle
+++ b/sampleApp/build.gradle
@@ -3,14 +3,15 @@ apply plugin: 'kotlin-android'
 
 android {
     defaultConfig {
-        compileSdk 34
-        buildToolsVersion = '34.0.0'
+        compileSdk 36
+        buildToolsVersion = '35.0.0'
     }
     namespace "com.doordeck.doordecksdk"
     defaultConfig {
         applicationId "com.doordeck.doordecksdk"
-        minSdkVersion 24
-        targetSdkVersion 34
+        minSdkVersion 26
+        targetSdkVersion 36
+        compileSdk 36
         versionCode 1
         versionName "1.2"
     }
@@ -42,7 +43,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
 
     implementation project(path: ':ui')
 

--- a/sampleApp/src/main/res/layout/activity_main.xml
+++ b/sampleApp/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <Button

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -10,9 +10,9 @@ android {
     def fallbackNfcUriScheme = "https"
 
     defaultConfig {
-        minSdkVersion 24
-        compileSdk 34
-        buildToolsVersion = '34.0.0'
+        minSdkVersion 26
+        compileSdk 36
+        buildToolsVersion = '35.0.0'
         multiDexEnabled = true
         versionName "1.2"
         vectorDrawables.useSupportLibrary = true
@@ -27,10 +27,12 @@ android {
         viewBinding true
         buildConfig true
     }
-
     packagingOptions {
-        exclude 'META-INF/atomicfu.kotlin_module'
+        resources {
+            excludes += ['META-INF/atomicfu.kotlin_module']
+        }
     }
+
 
     buildTypes.each { type ->
         type.manifestPlaceholders["nfc_uri_host"] = project.properties.get("nfcUri").getOrDefault("host", fallbackNfcUriHost)
@@ -87,13 +89,13 @@ dependencies {
     api(project(":api"))
 
     implementation 'com.github.adorsys:secure-storage-android:0.0.2'
-    implementation "org.immutables:value-annotations:2.7.5" // or implementation, or compileOnly
-    annotationProcessor "org.immutables:value:2.7.5"
-    testAnnotationProcessor "org.immutables:value:2.7.5"
+    implementation "org.immutables:value-annotations:2.11.1" // or implementation, or compileOnly
+    annotationProcessor "org.immutables:value:2.11.1"
+    testAnnotationProcessor "org.immutables:value:2.11.1"
 
-    implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
-    implementation "androidx.recyclerview:recyclerview:1.3.2"
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation "androidx.constraintlayout:constraintlayout:2.2.1"
+    implementation "androidx.recyclerview:recyclerview:1.4.0"
     implementation "androidx.cardview:cardview:1.0.0"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
@@ -103,12 +105,12 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
 
     // scan
-    implementation('com.journeyapps:zxing-android-embedded:4.1.0') { transitive = false }
+    implementation('com.journeyapps:zxing-android-embedded:4.3.0') { transitive = false }
 
-    implementation 'com.google.zxing:core:3.4.0'
+    implementation 'com.google.zxing:core:3.5.3'
 
     // location
-    implementation 'com.google.android.gms:play-services-auth:21.2.0'
+    implementation 'com.google.android.gms:play-services-auth:21.4.0'
     implementation 'com.google.android.gms:play-services-location:21.3.0'
 
     // kotlin

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity
             android:name="com.doordeck.sdk.ui.nfc.NFCActivity"
             android:screenOrientation="portrait"
+            android:launchMode="singleTop"
             android:exported="true"
             android:excludeFromRecents="true">
 

--- a/ui/src/main/res/layout/activity_nfc.xml
+++ b/ui/src/main/res/layout/activity_nfc.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:background="?attr/ddColorPrimary">
 
 

--- a/ui/src/main/res/layout/activity_qr_scan.xml
+++ b/ui/src/main/res/layout/activity_qr_scan.xml
@@ -2,6 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
+    android:fitsSystemWindows="true"
+    android:background="?attr/ddColorPrimary"
     android:layout_height="match_parent">
 
 

--- a/ui/src/main/res/layout/activity_verify_device.xml
+++ b/ui/src/main/res/layout/activity_verify_device.xml
@@ -3,6 +3,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:background="?attr/ddColorPrimary">
 
     <ImageView


### PR DESCRIPTION
Branch `legacy` was checked out from the latest tag [2.3.2](https://github.com/doordeck/doordeck-sdk-java/releases/tag/2.3.2)

New apps should migrate to [3.0.0](https://github.com/doordeck/doordeck-sdk-java/releases/tag/3.0.0).

This legacy update gives the availability to update to Google Requirements to satisfy API 35.