### PR TITLE
Updating various security tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    groups:
+      gradle-patch:
+        patterns: ["*"]
+        update-types: ["patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    groups:
+      actions-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,30 +25,12 @@ jobs:
         with:
           distribution: corretto
           java-version: 21
+          cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
 
       - name: Build
         run: ./gradlew build
-
-  dependency-submission:
-    name: "Update Dependency Graph"
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 21
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+# .github/workflows/codeql.yml
+name: "CodeQL (Advanced Security)"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "0 4 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze-code:
+    name: "Analyze (Java/Kotlin)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          queries: +security-extended
+
+      - name: Build
+        run: ./gradlew build -x test --no-daemon --no-build-cache
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+
+  analyze-actions:
+    name: "Analyze (GitHub Actions)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+          build-mode: none
+          queries: +security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,61 @@
+# .github/workflows/dependencies.yml
+name: Gradle Dependency Submission
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependency-submission:
+    name: "Update Dependency Graph"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+          cache: gradle
+
+      - name: Submit Dependency Graph
+        uses: gradle/actions/dependency-submission@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        if: github.event_name == 'pull_request'
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always
+          warn-on-openssf-scorecard-level: 2
+          allow-licenses: >-
+            MIT,
+            Apache-2.0,
+            BSD-3-Clause
+          # Restrictive licenses allowed in build tools
+          allow-dependencies-licenses: >-
+            pkg:githubactions/actions/dependency-review-action,
+            pkg:githubactions/actions/checkout,
+            pkg:githubactions/actions/setup-java,
+            pkg:githubactions/actions/gradle/actions/dependency-submission,
+            pkg:githubactions/actions/gradle/actions/setup-gradle,
+            pkg:maven/com.googlecode.juniversalchardet/juniversalchardet,
+            pkg:maven/net.java.dev.jna/jna-platform,
+            pkg:maven/javax.annotation/javax.annotation-api,
+            pkg:maven/org.jdom/jdom2,
+            pkg:maven/org.jacoco/org.jacoco.agent,
+            pkg:maven/org.jacoco/org.jacoco.ant,
+            pkg:maven/org.jacoco/org.jacoco.core,
+            pkg:maven/org.jacoco/org.jacoco.report

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,21 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
 }
 
 buildscript {
     configurations.all {
-        // Transitive dependencies
         resolutionStrategy {
-            force("org.apache.commons:commons-compress:1.28.0")
+            force(libs.jdom)
+            force(libs.jose4j)
 
             eachDependency {
-                when (requested.group) {
-                    "io.netty" -> useVersion("4.1.124.Final")
-                    "org.bouncycastle" -> useVersion("1.81")
-                    "io.grpc" -> useVersion("1.74.0")
-                    "com.google.protobuf" -> useVersion("3.25.5")
+                if (requested.group == "io.netty") {
+                    useVersion(libs.versions.netty.get())
+                    because("Various security fixes")
                 }
             }
         }
@@ -24,17 +21,10 @@ buildscript {
 
 allprojects {
     configurations.all {
-        // Transitive dependencies
-        resolutionStrategy {
-            force("org.apache.commons:commons-compress:1.28.0")
-
-            eachDependency {
-                when (requested.group) {
-                    "io.netty" -> useVersion("4.1.124.Final")
-                    "org.bouncycastle" -> useVersion("1.81")
-                    "io.grpc" -> useVersion("1.74.0")
-                    "com.google.protobuf" -> useVersion("3.25.5")
-                }
+        resolutionStrategy.eachDependency {
+            if (requested.group == "io.netty") {
+                useVersion(rootProject.libs.versions.netty.get())
+                because("Various security fixes")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,9 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 
 # Doordeck NFC URI settings
 nfcUri.scheme=https
 nfcUri.host=doordeck.link
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
-agp = "8.12.0"
+agp = "9.1.0"
 kotlin = "2.2.10"
+jdom = "2.0.6.1"
+jose4j = "0.9.6"
+netty = "4.1.132.Final"
 
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.1"
@@ -17,7 +20,10 @@ play-location = "com.google.android.gms:play-services-location:21.3.0"
 
 doordeck-headless-sdk = "com.doordeck.headless.sdk:doordeck-sdk:0.101.0"
 
+# Build dependencies
+jdom = { group = "org.jdom", name = "jdom2", version.ref = "jdom" }
+jose4j = { group = "org.bitbucket.b_c", name = "jose4j", version.ref = "jose4j" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sampleApp/build.gradle.kts
+++ b/sampleApp/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
     repositories {
         google()
         mavenCentral()

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     id("maven-publish")
 }
@@ -19,7 +18,6 @@ android {
     defaultConfig {
         minSdk = 26
         compileSdk = 35
-        buildToolsVersion = "35.0.0"
         vectorDrawables.useSupportLibrary = true
 
         resValue("string", "nfc_uri_host", nfcHost.get())
@@ -31,6 +29,7 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = true
+        resValues = true
     }
 
     buildTypes {
@@ -38,7 +37,7 @@ android {
             buildConfigField("String", "BASE_URL_API", "\"https://api.staging.doordeck.com\"")
             isMinifyEnabled = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android.txt"),
+                getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
         }
@@ -46,7 +45,7 @@ android {
             buildConfigField("String", "BASE_URL_API", "\"https://api.doordeck.com\"")
             isMinifyEnabled = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android.txt"),
+                getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
         }


### PR DESCRIPTION
- Bump `setup-graadle` to 6.0.1 and disable caching due to license changes
- Switch to manual CodeQL setup
- Added dependency review 
- Added dependabot configuration
- Upgraded to Gradle 9.3.1
- Upgraded AGP to 9.1.0
- Removed Kotlin Android plugin due to inclusion in new AGP version
- Fixed versions for netty, jdom, jose4j build dependencies